### PR TITLE
Add request caching

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ dash = "*"
 dash-daq = "*"
 werkzeug = "==0.14.1"
 pandas = "*"
+requests-cache = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "856c7ae26fd05d24ac8f0e0c8246b08c248cdc6cbdae89aba7820a7a47ae1b4d"
+            "sha256": "971fc8891527308a0b406dc3a505dab152a18368a40f15d88df33b1a798efd15"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -195,31 +195,31 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:1980f8d84548d74921685f68096911585fee393975f53797614b34d4f409b6da",
-                "sha256:22752cd809272671b273bb86df0f505f505a12368a3a5fc0aa811c7ece4dfd5c",
-                "sha256:23cc40313036cffd5d1873ef3ce2e949bdee0646c5d6f375bf7ee4f368db2511",
-                "sha256:2b0b118ff547fecabc247a2668f48f48b3b1f7d63676ebc5be7352a5fd9e85a5",
-                "sha256:3a0bd1edf64f6a911427b608a894111f9fcdb25284f724016f34a84c9a3a6ea9",
-                "sha256:3f25f6c7b0d000017e5ac55977a3999b0b1a74491eacb3c1aa716f0e01f6dcd1",
-                "sha256:4061c79ac2230594a7419151028e808239450e676c39e58302ad296232e3c2e8",
-                "sha256:560ceaa24f971ab37dede7ba030fc5d8fa173305d94365f814d9523ffd5d5916",
-                "sha256:62be044cd58da2a947b7e7b2252a10b42920df9520fc3d39f5c4c70d5460b8ba",
-                "sha256:6c692e3879dde0b67a9dc78f9bfb6f61c666b4562fd8619632d7043fb5b691b0",
-                "sha256:6f65e37b5a331df950ef6ff03bd4136b3c0bbcf44d4b8e99135d68a537711b5a",
-                "sha256:7a78cc4ddb253a55971115f8320a7ce28fd23a065fc33166d601f51760eecfa9",
-                "sha256:80a41edf64a3626e729a62df7dd278474fc1726836552b67a8c6396fd7e86760",
-                "sha256:893f4d75255f25a7b8516feb5766c6b63c54780323b9bd4bc51cdd7efc943c73",
-                "sha256:972ea92f9c1b54cc1c1a3d8508e326c0114aaf0f34996772a30f3f52b73b942f",
-                "sha256:9f1d4865436f794accdabadc57a8395bd3faa755449b4f65b88b7df65ae05f89",
-                "sha256:9f4cd7832b35e736b739be03b55875706c8c3e5fe334a06210f1a61e5c2c8ca5",
-                "sha256:adab43bf657488300d3aeeb8030d7f024fcc86e3a9b8848741ea2ea903e56610",
-                "sha256:bd2834d496ba9b1bdda3a6cf3de4dc0d4a0e7be306335940402ec95132ad063d",
-                "sha256:d20c0360940f30003a23c0adae2fe50a0a04f3e48dc05c298493b51fd6280197",
-                "sha256:d3b3ed87061d2314ff3659bb73896e622252da52558f2380f12c421fbdee3d89",
-                "sha256:dc235bf29a406dfda5790d01b998a1c01d7d37f449128c0b1b7d1c89a84fae8b",
-                "sha256:fb3c83554f39f48f3fa3123b9c24aecf681b1c289f9334f8215c1d3c8e2f6e5b"
+                "sha256:0e2eed77804b2a6a88741f8fcac02c5499bba3953ec9c71e8b217fad4912c56c",
+                "sha256:1c666f04553ef70fda54adf097dbae7080645435fc273e2397f26bbf1d127bbb",
+                "sha256:1f46532afa7b2903bfb1b79becca2954c0a04389d19e03dc73f06b039048ac40",
+                "sha256:315fa1b1dfc16ae0f03f8fd1c55f23fd15368710f641d570236f3d78af55e340",
+                "sha256:3d5fcea4f5ed40c3280791d54da3ad2ecf896f4c87c877b113576b8280c59441",
+                "sha256:48241759b99d60aba63b0e590332c600fc4b46ad597c9b0a53f350b871ef0634",
+                "sha256:4b4f2924b36d857cf302aec369caac61e43500c17eeef0d7baacad1084c0ee84",
+                "sha256:54fe3b7ed9e7eb928bbc4318f954d133851865f062fa4bbb02ef8940bc67b5d2",
+                "sha256:5a8f021c70e6206c317974c93eaaf9bc2b56295b6b1cacccf88846e44a1f33fc",
+                "sha256:754a6be26d938e6ca91942804eb209307b73f806a1721176278a6038869a1686",
+                "sha256:771147e654e8b95eea1293174a94f34e2e77d5729ad44aefb62fbf8a79747a15",
+                "sha256:78a6f89da87eeb48014ec652a65c4ffde370c036d780a995edaeb121d3625621",
+                "sha256:7fde5c2a3a682a9e101e61d97696687ebdba47637611378b4127fe7e47fdf2bf",
+                "sha256:80d99399c97f646e873dd8ce87c38cfdbb668956bbc39bc1e6cac4b515bba2a0",
+                "sha256:88a72c1e45a0ae24d1f249a529d9f71fe82e6fa6a3fd61414b829396ec585900",
+                "sha256:a4f4460877a16ac73302a9c077ca545498d9fe64e6a81398d8e1a67e4695e3df",
+                "sha256:a61255a765b3ac73ee4b110b28fccfbf758c985677f526c2b4b39c48cc4b509d",
+                "sha256:ab4896a8c910b9a04c0142871d8800c76c8a2e5ff44763513e1dd9d9631ce897",
+                "sha256:abbd6b1c2ef6199f4b7ca9f818eb6b31f17b73a6110aadc4e4298c3f00fab24e",
+                "sha256:b16d88da290334e33ea992c56492326ea3b06233a00a1855414360b77ca72f26",
+                "sha256:b78a1defedb0e8f6ae1eb55fa6ac74ab42acc4569c3a2eacc2a407ee5d42ebcb",
+                "sha256:cfef82c43b8b29ca436560d51b2251d5117818a8d1fb74a8384a83c096745dad",
+                "sha256:d160e57731fcdec2beda807ebcabf39823c47e9409485b5a3a1db3a8c6ce763e"
             ],
-            "version": "==1.16.2"
+            "version": "==1.16.3"
         },
         "pandas": {
             "hashes": [
@@ -249,10 +249,10 @@
         },
         "plotly": {
             "hashes": [
-                "sha256:8e1b323b20bb2e726cd1d5ea73c6ca7b13664513f7846e283cfed775f7cc4b26",
-                "sha256:d69455e8214b6dcf5a6c56964062ab8e36c6909aff7ae1b629107b71e28a1ac0"
+                "sha256:04708425517a7bdf4855976b8f91b647282104b3419bd097ff42655238793a4f",
+                "sha256:51eb88e82dc2221cf3cf84f5bf5a348597358e57285e436436baaee7e0a7f436"
             ],
-            "version": "==3.8.0"
+            "version": "==3.8.1"
         },
         "pyrsistent": {
             "hashes": [
@@ -299,6 +299,14 @@
             "index": "pypi",
             "version": "==2.21.0"
         },
+        "requests-cache": {
+            "hashes": [
+                "sha256:6822f788c5ee248995c4bfbd725de2002ad710182ba26a666e85b64981866060",
+                "sha256:73a7211870f7d67af5fd81cad2f67cfe1cd3eb4ee6a85155e07613968cc72dfc"
+            ],
+            "index": "pypi",
+            "version": "==0.5.0"
+        },
         "retrying": {
             "hashes": [
                 "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"
@@ -328,10 +336,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
+                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
             ],
-            "version": "==1.24.1"
+            "version": "==1.24.2"
         },
         "werkzeug": {
             "hashes": [

--- a/graps.py
+++ b/graps.py
@@ -9,6 +9,7 @@ import yaml
 from enum import Enum
 import sqlite3
 from datetime import date
+import argparse
 
 
 class ContentType(Enum):
@@ -148,7 +149,8 @@ def parse_workers(url):
         all_workers = html.find("div", {"class": "Comments Font9"})
         worker_list = (u''.join(str(item) for item in all_workers)).split(",")
         for worker in worker_list:
-            print("\'" + worker + "\'")
+            if args.verbose:
+                print("Scraped worker being parsed: \'" + worker + "\'")
             worker_id = None
             worker_name = None
             worker_soup = BeautifulSoup(worker, 'html.parser')
@@ -170,12 +172,21 @@ def parse_workers(url):
 
 
 def main():
-    with open("shows.yaml", 'r') as yamlfile:
+    with open(args.filename, 'r') as yamlfile:
         shows = yaml.safe_load(yamlfile)
 
     for show in shows:
         parse_workers(show)
 
+
+parser = argparse.ArgumentParser(description='Scrape and parse a list of shows')
+parser.add_argument("-f", "--file", dest="filename",
+                    help="file to be loaded", metavar="FILE",
+                    default="shows.yaml")
+parser.add_argument("-v", "--verbose", dest="verbose",
+                    help="output more info about what's being parsed",
+                    action="store_true")
+args = parser.parse_args()
 
 conn = sqlite3.connect('thedatabase.sqlite3', check_same_thread=False)
 c = conn.cursor()

--- a/url_loading.py
+++ b/url_loading.py
@@ -6,6 +6,8 @@ MDK
 from requests import get
 from requests.exceptions import RequestException
 from contextlib import closing
+import requests_cache
+
 
 def simple_get(url):
     """
@@ -15,6 +17,7 @@ def simple_get(url):
     """
     try:
         with closing(get(url, stream=True)) as resp:
+            print("URL: {0} / Used Cache: {1}".format(url, resp.from_cache))
             if is_good_response(resp):
                 return resp.content
             else:
@@ -42,3 +45,6 @@ def log_error(e):
     make it do anything.
     """
     print(e)
+
+
+requests_cache.install_cache(cache_name='cagematch_cache', backend='sqlite')


### PR DESCRIPTION
Adds caching using requests-cache.  Caches to a 
SQLite database 'cagematch_cache.sqlite'
Also adds argparse, and two arguments:
-f/--file specifies the yaml file of shows to load
-v/--verbose will only output the worker string we're 
parsing if true

Fixes #14 