### PR TITLE
Fix end of bracketed tag team member being skipped

### DIFF
--- a/graps.py
+++ b/graps.py
@@ -141,7 +141,7 @@ def not_one_off(worker_name, search):
     :param search: the match result to match against
     :return: True if the regex matches, in other words does not match the one off pattern
     """
-    return bool(re.search(worker_name + "(( \\(([c\\)]|[w\\/]))|( [^(])|$)", search))
+    return bool(re.search(worker_name + "(( \\(([c\\)]|[w\\/]))|( [^(])|$|\\))", search))
 
 
 def parse_workers(url):

--- a/test_regex.py
+++ b/test_regex.py
@@ -8,6 +8,8 @@ def test_one_off_regex():
     assert not_one_off("El Motho", "El Motho (w/Jinny)") is True, "Should match"
     assert not_one_off("El Motho", "El Motho defeats Gabriel Kidd") is True, "Should match"
     assert not_one_off("El Motho", "Gabriel Kidd defeats El Motho") is True, "Should match"
+    assert not_one_off("El Motho", "The Knucklelockers (Darrell Allen & El Motho) defeat The NIC (Charlie Carter & Oisin Delaney)") is True, "Should match"
+    assert not_one_off("El Motho", "The Knucklelockers (Darrell Allen & Jordon Breaks) defeat The NIC (Charlie Carter & El Motho)") is True, "Should match"
 
 
 def test_translation():


### PR DESCRIPTION
If a wrestler with no profile was at the end of a
bracketed tag team, the regex skipped them. The 
regex now checks for an end bracket as it would for
an EOL.

Fixes #27