### PR TITLE
Add partial shows

### DIFF
--- a/graps.py
+++ b/graps.py
@@ -8,21 +8,29 @@ from urllib.parse import urlparse
 from urllib.parse import parse_qs
 from url_loading import simple_get
 import yaml
-from enum import Enum
+from enum import IntEnum
 import sqlite3
 from datetime import date
 import argparse
 import re
+import cProfile
+
 
 TYPE_FIELD = 'id'
 ID_FIELD = 'nr'
 
 
-class ContentType(Enum):
+class ContentType(IntEnum):
     WRESTLER = 2
     PROMOTION = 8
     TAG_TEAM = 28
     STABLE = 29
+
+    
+class ShowType(IntEnum):
+    NORMAL = 0
+    PARTIAL = 1
+    PARTIAL_EXCLUDED = 2
 
 
 @dataclass
@@ -39,6 +47,7 @@ class Show:
     show_name: str
     promotion: Promotion
     url: str
+    is_partial: ShowType = ShowType.NORMAL
 
 
 @dataclass
@@ -61,6 +70,7 @@ def create_tables():
             "show_date" TEXT,
             "promotion" INTEGER,
             "url" TEXT,
+            "is_partial" INTEGER,
             FOREIGN KEY ("promotion") REFERENCES
                 "promotions" ("promotion_id"));
               ''')
@@ -93,9 +103,9 @@ def add_show(show):
     """
     Inserts the specified show into the shows table.
     """
-    c.execute('''INSERT OR IGNORE INTO shows(show_id, name, arena, show_date, promotion, url)
-                 VALUES(?,?,?,?,?,?)''',
-              (show.show_id, show.show_name, show.arena, show.date, show.promotion.id, show.url))
+    c.execute('''INSERT OR IGNORE INTO shows(show_id, name, arena, show_date, promotion, url, is_partial)
+                 VALUES(?,?,?,?,?,?,?)''',
+              (show.show_id, show.show_name, show.arena, show.date, show.promotion.id, show.url, show.is_partial))
     conn.commit()
 
 
@@ -125,13 +135,69 @@ def validate_worker(worker_name, bs_html):
     :param bs_html: the HTML as passed through BeautifulSoup
     :return: True if the worker is valid, False if it should be rejected
     """
+    result = False
     divs = bs_html.find("div", {"class": "Matches"})
     for div in divs:
         result = div.find("div", {"class": "MatchResults"})
         if not_one_off(worker_name, result.text.strip()):
-            return True
+            result = True
+    return result
 
-    return False
+
+def filter_excluded(workers, exclude, bs_html):
+    """
+    Exclude wrestlers who only appear in matches that have been marked for exclusion from the parsed
+    list of workers.
+    :param workers: the list of worker objects parsed from the All Workers section
+    :param exclude: the indexes of matches to exclude
+    :param bs_html: the HTML as passed through BeautifulSoup
+    :return: the workers list with wrestlers only in excluded matches removed
+    """
+    exclude_matches = []
+    include_matches = []
+    divs = bs_html.find("div", {"class": "Matches"})
+    i = 1
+    for div in divs:
+        result = div.find("div", {"class": "MatchResults"})
+        if i in exclude:
+            exclude_matches.append(result)
+        else:
+            include_matches.append(result)
+        i = i + 1
+
+    if args.verbose:
+        print("Excluding matches: {0}, Including matches: {1}".format(exclude_matches, include_matches))
+
+    newlist = []
+    for worker in workers:
+        if isinstance(worker.id, int):
+            found_exclude = False
+            for result in exclude_matches:
+                for profile_link in result.find_all('a'):
+                    if profile_link is not None:
+                        worker_id, worker_name = extract_worker_id_name(profile_link)
+                        if worker_id == worker.id:
+                            found_exclude = True
+            if found_exclude:
+                found_include = False
+                for result in include_matches:
+                    for profile_link in result.find_all('a'):
+                        if profile_link is not None:
+                            worker_id, worker_name = extract_worker_id_name(profile_link)
+                            if worker_id == worker.id:
+                                found_include = True
+            if found_exclude and not found_include:
+                if args.verbose:
+                    print("Excluding wrestler {0}".format(worker))
+            else:
+                newlist.append(worker)
+        elif any(worker.name in s for s in exclude_matches) and not any(worker.name in s for s in include_matches):
+            if args.verbose:
+                print("Excluding wrestler {0}".format(worker))
+        else:
+            newlist.append(worker)
+        
+    return newlist
 
 
 def not_one_off(worker_name, search):
@@ -156,16 +222,29 @@ def parse_workers(url):
     shows = []
     all_workers = []
     for url in urls:
+        url, is_partial = check_is_partial(url)
+        if is_partial:
+            exclude = url['exclude']
+            exclude_from_count = url.get('exclude_from_count') or False
+            if exclude_from_count:
+                show_type = ShowType.PARTIAL_EXCLUDED
+            else:
+                show_type = ShowType.PARTIAL
+            url = url['url']
+        else:
+            show_type = ShowType.NORMAL
         raw_html = simple_get(url)
         if raw_html is not None:
             html = BeautifulSoup(raw_html, 'html.parser')
 
-            show = parse_show_info(html, url)
+            show = parse_show_info(html, url, show_type)
             shows.append(show)
             if args.verbose:
                 print("Parsed show info {0}".format(show))
 
             workers = parse_worker_list(html)
+            if show_type > 0:
+                workers = filter_excluded(workers, exclude, html)
             all_workers.extend(workers)
 
     if len(shows) > 1:
@@ -194,18 +273,31 @@ def parse_workers(url):
 
 def get_urls(url):
     """
-    Check if the URL is a dict. If so, return an array of the sub-items. If not, return an array containing just the
-    input url.
+    Check if the URL is a dict. If so, and the dict is named one of 'merge', 'taping' or 'squash', return
+    an array of the sub-items. If not, return an array containing just the input url.
     :param url: A URL str or a dict of URLs
     :return: a list of urls
     """
-    urls = []
+    urls = [url]
     if isinstance(url, dict):
         if any([i in url for i in ['merge', 'taping', 'squash']]):
             urls = url.get('merge') or url.get('taping') or url.get('squash')
-    else:
-        urls = [url]
     return urls
+
+
+def check_is_partial(url):
+    """
+    Check if the URL is a dict. If so, and the dict is named 'partial', return the sub-items, and True to indicate
+    this. If not, return the input url and False.
+    :param url: A URL str or a dict of URLs
+    :return: the dict structure for a partial show entry, or the url, and True or False respectively
+    """
+    if isinstance(url, dict):
+        if any([i in url for i in ['partial']]):
+            partial_dict = url.get('partial')
+            return partial_dict, True
+    else:
+        return url, False
 
 
 def parse_worker_list(html):
@@ -227,11 +319,7 @@ def parse_worker_list(html):
         worker_soup = BeautifulSoup(worker, 'html.parser')
         profile_link = worker_soup.find('a')
         if profile_link is not None:
-            query_parts = parse_qs(urlparse(profile_link.attrs['href']).query)
-            link_type = int(query_parts.get(TYPE_FIELD)[0])
-            if ContentType(link_type) is ContentType.WRESTLER:
-                worker_id = int(query_parts.get(ID_FIELD)[0])
-                worker_name = profile_link.text
+            worker_id, worker_name = extract_worker_id_name(profile_link)
         else:
             plain_text_name = worker.strip()
             if validate_worker(plain_text_name, html):
@@ -246,11 +334,28 @@ def parse_worker_list(html):
     return ret
 
 
-def parse_show_info(html, url):
+def extract_worker_id_name(profile_link):
+    """
+    From a discovered 'a' tag, check type field to verify ContentType.WRESTLER, then extract ID and Name
+    :param profile_link: a discovered BeautifulSoup 'a' tag
+    :return: int worker ID and text name (worker_id, worker_name)
+    """
+    worker_id = None
+    worker_name = None
+    query_parts = parse_qs(urlparse(profile_link.attrs['href']).query)
+    link_type = int(query_parts.get(TYPE_FIELD)[0])
+    if link_type == ContentType.WRESTLER:
+        worker_id = int(query_parts.get(ID_FIELD)[0])
+        worker_name = profile_link.text
+    return worker_id, worker_name
+
+
+def parse_show_info(html, url, show_type):
     """
     From the souped HTML, create a dictionary for the show info table, and extract the relevant portions.
     :param html: the HTML as passed through BeautifulSoup
     :param url: the show URL
+    :param show_type: whether the show is a partial show
     :return: a Show object
     """
     dictionary = get_show_information_dictionary(html)
@@ -260,20 +365,21 @@ def parse_show_info(html, url):
     date_str = dictionary["Date:"].get_text()
     dd, mm, yy = date_str.split(".")
     date_obj = date(int(yy), int(mm), int(dd))
-    show_name = apply_translations(dictionary["Name of the event:"])
+    show_name = apply_translations(dictionary["Name of the event:"], args.dntranslate)
     promotion_str = dictionary["Promotion:"]
     promotion = parse_promotion_info(promotion_str)
-    return Show(show_id, arena, date_obj, show_name, promotion, url)
+    return Show(show_id, arena, date_obj, show_name, promotion, url, show_type)
 
 
-def apply_translations(show_name):
+def apply_translations(show_name, dntranslate=False):
     """
     Apply the following translations to strings:
       - 'Tag {x}' to 'Day {x}'
     :param show_name: the input string to translate
+    :param dntranslate: whether translation should be skipped (retrieve from args)
     :return: the translated string
     """
-    if args.dntranslate:
+    if dntranslate:
         return show_name
     else:
         return re.sub(r"(Tag)( [0-9]+)", r"Day\2", show_name)
@@ -289,7 +395,7 @@ def parse_promotion_info(promotion_str):
     if promotion_str is not None:
         query_parts = parse_qs(urlparse(promotion_str.attrs['href']).query)
         link_type = int(query_parts.get(TYPE_FIELD)[0])
-        if ContentType(link_type) is ContentType.PROMOTION:
+        if link_type == ContentType.PROMOTION:
             promotion_id = int(query_parts.get(ID_FIELD)[0])
             return Promotion(promotion_id, promotion_str.text)
     else:
@@ -332,9 +438,18 @@ if __name__ == "__main__":
     parser.add_argument("-t", "--no-translations", dest="dntranslate",
                         help="don't perform translations, e.g Tag -> Day in show names",
                         action="store_true")
+    parser.add_argument("-p", "--profile", dest="profiler",
+                        help="run profiling",
+                        action="store_true")
     args = parser.parse_args()
 
     conn = sqlite3.connect('thedatabase.sqlite3', check_same_thread=False)
     c = conn.cursor()
+    if args.profiler:
+        pr = cProfile.Profile()
+        pr.enable()
     create_tables()
     main()
+    if args.profiler:
+        pr.disable()
+        pr.print_stats()

--- a/tests/test_partial.yaml
+++ b/tests/test_partial.yaml
@@ -1,0 +1,25 @@
+- taping:
+    - https://www.cagematch.net/?id=1&nr=50217 # WWE NXT #1.08
+    - https://www.cagematch.net/?id=1&nr=50226 # WWE Friday Night SmackDown #556
+    - partial:
+        url: https://www.cagematch.net/?id=1&nr=50185 # WWE Superstars #53 : only one match
+        exclude: [2,3]
+- https://www.cagematch.net/?id=1&nr=94731 # RevPro When Thunder Strikes
+- partial:
+    url: https://www.cagematch.net/?id=1&nr=184094 # EVE SHEroes! : Had to leave after 3 matches
+    exclude: [4,5,6,7,8]
+- partial:
+    url: https://www.cagematch.net/?id=1&nr=186937 # EVE Wrestle Queendom: left after one match
+    exclude: [2,3,4,5,6]
+    exclude_from_count: True
+- merge:
+    - partial:
+        url: https://www.cagematch.net/?id=1&nr=242611
+        exclude: [1] # Exclude match 1 with Martin Kirby, who is in a match on the other show, so should still appear
+    - https://www.cagematch.net/?id=1&nr=242612
+- partial:
+    url: https://www.cagematch.net/?id=1&nr=239089
+    exclude: [5] # Match 5 contains KAI, but Match 3 features Kaito Ishida, will this conflict?
+- partial:
+    url: https://www.cagematch.net/?id=1&nr=236880
+    exclude: [5] # Match 5 contains LA Park, but Match 4 features El Hijo de LA Park & LA Park Jr., will this conflict?


### PR DESCRIPTION
graps.py:
- Add 'partial' flag to database, with 1 indicating a
  partial show, and 2 a partial show to be excluded
  from totals
- Add filter_excluded method which removes 
  wrestlers who only appear in excluded matches
  from the list
- Change ContentType Enum to IntEnum to allow
  direct comparison
- Add ShowType IntEnum
- Add initial profiling support using cProfile, enabled
  with -p/--profile flag

app.py:
- Exclude partial-excluded shows from show counts
- Add count of partial-excluded shows where > 0

Add test_partial.yaml with two edge cases that have
been addressed

Fixes #13 